### PR TITLE
Remove `elsif` -> `elseif` rule

### DIFF
--- a/plugin/fat-finger.vim
+++ b/plugin/fat-finger.vim
@@ -1407,7 +1407,6 @@ iabbrev ellected elected
 iabbrev elphant elephant
 iabbrev elsef elseif
 iabbrev elseof elseif
-iabbrev elsif elseif
 iabbrev elsiof elseif
 iabbrev elsof elseif
 iabbrev embarass embarrass


### PR DESCRIPTION
`elsif` is actually a keyword in ruby